### PR TITLE
Define url as string or File

### DIFF
--- a/exif.d.ts
+++ b/exif.d.ts
@@ -1,5 +1,5 @@
 interface EXIFStatic {
-    getData(url: string, callback: any): any;
+    getData(url: string | File, callback: any): any;
     getTag(img: any, tag: any): any;
     getAllTags(img: any): any;
     pretty(img: any): string;


### PR DESCRIPTION
Define url as string or File, for TypeScript, as the function can accept File objects. This prevents linting errors.